### PR TITLE
release: 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Add new linter rules:
 - [unnecessary_parenthesis](https://dart.dev/tools/linter-rules/unnecessary_parenthesis) — Removes brackets
 
 - [unnecessary_statements](https://dart.dev/tools/linter-rules/unnecessary_statements) — Avoids having statements that return a result but aren't used.
+
 - [unreachable_from_main](https://dart.dev/tools/linter-rules/unreachable_from_main) — Any member declared in an executable library should be used directly inside that library.
 
 ## 1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 1.0.3
+
+Add new linter rules:
+
+- [always_put_control_body_on_new_line](https://dart.dev/tools/linter-rules/always_put_control_body_on_new_line) — Along with curly_braces_in_flow_control_structures will help us to create flow breakers more organically (e.g. avoid having `if (..) return;`)
+    
+- [avoid_slow_async_io](https://dart.dev/tools/linter-rules/avoid_slow_async_io) — Instead of using certain async IO function, dart suggests to use their sync alternatives
+
+- [directives_ordering](https://dart.dev/tools/linter-rules/directives_ordering) — Sort imports
+
+- [matching_super_parameters](https://dart.dev/tools/linter-rules/matching_super_parameters) — If you inherit from a class, make sure the constructor params sequence match the parent's params
+
+- [no_self_assignments](https://dart.dev/tools/linter-rules/no_self_assignments) — Avoid having `a = a;`
+
+- [prefer_asserts_in_initializer_lists](https://dart.dev/tools/linter-rules/prefer_asserts_in_initializer_lists) — Put asserts on the initializer level, not in to the constructor body
+
+- [unnecessary_await_in_return](https://dart.dev/tools/linter-rules/unnecessary_await_in_return) — No need to await before returning
+
+- [unnecessary_breaks](https://dart.dev/tools/linter-rules/unnecessary_breaks) — No need for a break unless you want to end execution earlier.
+
+- [unnecessary_lambdas](https://dart.dev/tools/linter-rules/unnecessary_lambdas) — If a method's parameters match the parameters of a required callback, don't create a lambda but pass the method directly as a tear-off.
+
+- [unnecessary_library_directive](https://dart.dev/tools/linter-rules/unnecessary_library_directive) — If `library` directive doesn't provide a name, it's not needed
+
+- [unnecessary_null_aware_operator_on_extension_on_nullable](https://dart.dev/tools/linter-rules/unnecessary_null_aware_operator_on_extension_on_nullable) — If an extension is declared on a nullable type, no need to do the check
+
+- [unnecessary_null_checks](https://dart.dev/tools/linter-rules/unnecessary_null_checks) — Removes null checks, e.g. if a function accepts a nullable variable there's no reason to pass it as `v!`
+
+- [unnecessary_parenthesis](https://dart.dev/tools/linter-rules/unnecessary_parenthesis) — Removes brackets
+
+- [unnecessary_statements](https://dart.dev/tools/linter-rules/unnecessary_statements) — Avoids having statements that return a result but aren't used.
+
 ## 1.0.2
 
 * Add platforms information to pub.dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Add new linter rules:
 - [unnecessary_parenthesis](https://dart.dev/tools/linter-rules/unnecessary_parenthesis) — Removes brackets
 
 - [unnecessary_statements](https://dart.dev/tools/linter-rules/unnecessary_statements) — Avoids having statements that return a result but aren't used.
+- [unreachable_from_main](https://dart.dev/tools/linter-rules/unreachable_from_main) — Any member declared in an executable library should be used directly inside that library.
 
 ## 1.0.2
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or add it to the `pubspec.yaml` yourself:
 
 ```yaml
 dev_dependencies:
-  monstarlab_lints: ^1.0.2
+  monstarlab_lints: ^1.0.3
 ```
 
 ### Configure analysis options
@@ -32,5 +32,5 @@ include: package:monstarlab_lints/analysis_options.yaml
 
 
 <!-- References -->
-[pub-version-img]: https://img.shields.io/badge/pub-v1.0.2-0175c2?logo=flutter
+[pub-version-img]: https://img.shields.io/badge/pub-v1.0.3-0175c2?logo=flutter
 [pub-version-url]: https://pub.dev/packages/monstarlab_lints

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -3,8 +3,9 @@
 
 linter:
   rules:
-    # https://github.com/dart-lang/linter/blob/master/example/all.yaml
+    # https://dart.dev/tools/linter-rules
     - always_declare_return_types
+    - always_put_control_body_on_new_line
     - always_require_non_null_named_parameters
     - always_use_package_imports
     - annotate_overrides
@@ -17,6 +18,7 @@ linter:
     - avoid_return_types_on_setters
     - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
+    - avoid_slow_async_io
     - avoid_types_as_parameter_names
     - avoid_unnecessary_containers
     - avoid_unused_constructor_parameters
@@ -25,15 +27,19 @@ linter:
     - await_only_futures
     - camel_case_extensions
     - curly_braces_in_flow_control_structures
+    - directives_ordering
     - empty_catches
     - empty_constructor_bodies
     - library_names
     - library_prefixes
+    - matching_super_parameters
     - no_duplicate_case_values
     - no_logic_in_create_state
+    - no_self_assignments
     - null_closures
     - omit_local_variable_types
     - prefer_adjacent_string_concatenation
+    - prefer_asserts_in_initializer_lists
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -58,12 +64,21 @@ linter:
     - sort_child_properties_last
     - type_init_formals
     - unawaited_futures
+    - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
+    - unnecessary_breaks
     - unnecessary_const
     - unnecessary_getters_setters
+    - unnecessary_lambdas
+    - unnecessary_library_directive
     - unnecessary_new
+    - unnecessary_null_aware_operator_on_extension_on_nullable
+    - unnecessary_null_checks
     - unnecessary_null_in_if_null_operators
+    - unnecessary_parenthesis
+    - unnecessary_statements
     - unnecessary_this
+    - unreachable_from_main
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monstarlab_lints
 description: Flutter lint rules used in Monstarlab EMEA.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/monstar-lab-oss/flutter_lints
 repository: https://github.com/monstar-lab-oss/flutter_lints
 issue_tracker: https://github.com/monstar-lab-oss/flutter_lints/issues


### PR DESCRIPTION
Add new linter rules:

- [always_put_control_body_on_new_line](https://dart.dev/tools/linter-rules/always_put_control_body_on_new_line) — Along with curly_braces_in_flow_control_structures will help us to create flow breakers more organically (e.g. avoid having `if (..) return;`)

- [avoid_slow_async_io](https://dart.dev/tools/linter-rules/avoid_slow_async_io) — Instead of using certain async IO function, dart suggests to use their sync alternatives

- [directives_ordering](https://dart.dev/tools/linter-rules/directives_ordering) — Sort imports

- [matching_super_parameters](https://dart.dev/tools/linter-rules/matching_super_parameters) — If you inherit from a class, make sure the constructor params sequence match the parent's params

- [no_self_assignments](https://dart.dev/tools/linter-rules/no_self_assignments) — Avoid having `a = a;`

- [prefer_asserts_in_initializer_lists](https://dart.dev/tools/linter-rules/prefer_asserts_in_initializer_lists) — Put asserts on the initializer level, not in to the constructor body

- [unnecessary_await_in_return](https://dart.dev/tools/linter-rules/unnecessary_await_in_return) — No need to await before returning

- [unnecessary_breaks](https://dart.dev/tools/linter-rules/unnecessary_breaks) — No need for a break unless you want to end execution earlier.

- [unnecessary_lambdas](https://dart.dev/tools/linter-rules/unnecessary_lambdas) — If a method's parameters match the parameters of a required callback, don't create a lambda but pass the method directly as a tear-off.

- [unnecessary_library_directive](https://dart.dev/tools/linter-rules/unnecessary_library_directive) — If `library` directive doesn't provide a name, it's not needed

- [unnecessary_null_aware_operator_on_extension_on_nullable](https://dart.dev/tools/linter-rules/unnecessary_null_aware_operator_on_extension_on_nullable) — If an extension is declared on a nullable type, no need to do the check

- [unnecessary_null_checks](https://dart.dev/tools/linter-rules/unnecessary_null_checks) — Removes null checks, e.g. if a function accepts a nullable variable there's no reason to pass it as `v!`

- [unnecessary_parenthesis](https://dart.dev/tools/linter-rules/unnecessary_parenthesis) — Removes brackets

- [unnecessary_statements](https://dart.dev/tools/linter-rules/unnecessary_statements) — Avoids having statements that return a result but aren't used.