### PR TITLE
workflows

### DIFF
--- a/.github/workflows/push_to_pubdev_on_tag.yml
+++ b/.github/workflows/push_to_pubdev_on_tag.yml
@@ -1,0 +1,14 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: ''
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Modify your [`analysis_options.yaml`](https://dart.dev/tools/analysis#the-analys
 include: package:monstarlab_lints/analysis_options.yaml
 ```
 
+## Maintaining
+
+To publish a new version to pub.dev, create a new tag with required version used as a title. For example, creating a tag `1.0.3` will result in pushing the package to pub.dev with version `1.0.3`.
+
 
 <!-- References -->
 [pub-version-img]: https://img.shields.io/badge/pub-v1.0.2-0175c2?logo=flutter


### PR DESCRIPTION
This workflow (along with some configuration on pub.dev) will allow us to publish new versions of the package by simply creating a new tag.