### PR TITLE
release: 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
+# Changelog
+
+## 1.0.4
+
+Add new linter rules:
+
+- [non_constant_identifier_names](https://dart.dev/tools/linter-rules/non_constant_identifier_names) — helps to maintain naming conventions.
+
 ## 1.0.3
 
 Add new linter rules:
 
 - [always_put_control_body_on_new_line](https://dart.dev/tools/linter-rules/always_put_control_body_on_new_line) — Along with curly_braces_in_flow_control_structures will help us to create flow breakers more organically (e.g. avoid having `if (..) return;`)
-    
+
 - [avoid_slow_async_io](https://dart.dev/tools/linter-rules/avoid_slow_async_io) — Instead of using certain async IO function, dart suggests to use their sync alternatives
 
 - [directives_ordering](https://dart.dev/tools/linter-rules/directives_ordering) — Sort imports
@@ -34,12 +42,12 @@ Add new linter rules:
 
 ## 1.0.2
 
-* Add platforms information to pub.dev
+- Add platforms information to pub.dev
 
 ## 1.0.1
 
-* Typo fix.
+- Typo fix.
 
 ## 1.0.0
 
-* Initial release.
+- Initial release.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or add it to the `pubspec.yaml` yourself:
 
 ```yaml
 dev_dependencies:
-  monstarlab_lints: ^1.0.3
+  monstarlab_lints: ^1.0.4
 ```
 
 ### Configure analysis options
@@ -34,7 +34,6 @@ include: package:monstarlab_lints/analysis_options.yaml
 
 To publish a new version to pub.dev, create a new tag with required version used as a title. For example, creating a tag `1.0.3` will result in pushing the package to pub.dev with version `1.0.3`.
 
-
 <!-- References -->
-[pub-version-img]: https://img.shields.io/badge/pub-v1.0.3-0175c2?logo=flutter
+[pub-version-img]: https://img.shields.io/badge/pub-v1.0.4-0175c2?logo=flutter
 [pub-version-url]: https://pub.dev/packages/monstarlab_lints

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -6,7 +6,6 @@ linter:
     # https://dart.dev/tools/linter-rules
     - always_declare_return_types
     - always_put_control_body_on_new_line
-    - always_require_non_null_named_parameters
     - always_use_package_imports
     - annotate_overrides
     - avoid_init_to_null
@@ -34,6 +33,7 @@ linter:
     - library_prefixes
     - matching_super_parameters
     - no_duplicate_case_values
+    - non_constant_identifier_names
     - no_logic_in_create_state
     - no_self_assignments
     - null_closures

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monstarlab_lints
 description: Flutter lint rules used in Monstarlab EMEA.
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/monstar-lab-oss/flutter_lints
 repository: https://github.com/monstar-lab-oss/flutter_lints
 issue_tracker: https://github.com/monstar-lab-oss/flutter_lints/issues


### PR DESCRIPTION
`always_require_non_null_named_parameters` was removed due to it was deprecated.